### PR TITLE
Add img_row0 and img_col0 to information table for L1

### DIFF
--- a/aca_movie.pl
+++ b/aca_movie.pl
@@ -407,7 +407,9 @@ sub get_image_frame {
     for $s (@slot) {
 	# Clear all the information table information for this slot and set all
 	# limit-checked msids to have the default background color
-	map { $info_table_txt[$_][$s+1] = '      ' } (0 .. $#info_msid);
+        for my $im (0 .. $#info_msid){
+	  $info_table_txt[$im][$s+1] = '      ';
+        }
 	foreach (values %limit_msids) {
 	    $info_table->get($_, $s+1)->configure(-background=>'#d5d5d5');
 	}


### PR DESCRIPTION
This seemingly benign change causes reproducible (for me) segfaults / core dumps on CentOS-5 and 6.  Any clue why?

To reproduce:

```
$ ./aca_movie.pl -nolog obs15129
```

Then soon after it starts playing hit "Pause" and then "Resume".

cc: @jeanconn 
