### PR TITLE
Use asp1 asol times to try to find l0 data if not in sybase 

### DIFF
--- a/aca_movie.pl
+++ b/aca_movie.pl
@@ -148,7 +148,7 @@ if ($opt{obsid}){
           # Get a list of L1 ACA image files
           my $asp1_dir = $obs_dirs[-1];
           my $l1_glob = "$asp1_dir/pcad*asol1.fits*";
-          my @files = glob($l1_glob);
+          my @files = sort(glob($l1_glob));
           croak("no asol files found for obsid in $asp1_dir") unless @files;
           # Set reasonable value of tstart based on first file name timestamp
           # and then read last file for final tstop

--- a/aca_movie.pl
+++ b/aca_movie.pl
@@ -150,8 +150,8 @@ if ($opt{obsid}){
           my $l1_glob = "$asp1_dir/pcad*asol1.fits*";
           my @files = sort(glob($l1_glob));
           croak("no asol files found for obsid in $asp1_dir") unless @files;
-          # Set reasonable value of tstart based on first file name timestamp
-          # and then read last file for final tstop
+          # Use first file start minus some time for acquisition and last file
+          # stop as the range for this tool
           my $hdr0 = CFITSIO::Simple::fits_read_hdr($files[0]);
           $start = time2date($hdr0->{TSTART} - 300);
           my $hdr1 = CFITSIO::Simple::fits_read_hdr($files[-1]);


### PR DESCRIPTION
Use asp1 asol times to try to find l0 data if not in sybase 

aca_movie.pl is set to use the "observations_all" sybase table to try to get times for observations when in L0 mode.  We should probably change that over to kadi at some point anyway.  This PR is a hack that just uses the times from the L1 aspect solutions in mica to then go and get the L0 data to view.  The L1 data is just stored in obsid directories, so the interface is simple.  

I used this hack to look at some early mission data which was not in the observations_all table, and would not have been in kadi.